### PR TITLE
chore(ci): fetch tags for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm


### PR DESCRIPTION
## Summary
- fetch tags during the release workflow checkout so release-it sees previous tags

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6892947f35e48330b44f634c8d512386