### PR TITLE
fix: resolve TypeScript configuration errors

### DIFF
--- a/packages/providers/tsconfig.lint.json
+++ b/packages/providers/tsconfig.lint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/pub.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "strict": false,
+    "strict": true,
     "strictNullChecks": true,
     "noEmit": true,
     "allowJs": true,
@@ -19,9 +19,9 @@
     "incremental": true,
     "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     "paths": {
-      "@/*": ["./packages/instructor-stream/src/*", "./src/*"],
-      "@core/*": ["./src/core/*"],
-      "@providers/*": ["./src/providers/*"]
+      "@/*": ["./packages/instructor-stream/src/*"],
+      "@core/*": ["./packages/instructor-stream/src/core/*"],
+      "@providers/*": ["./packages/providers/src/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
Fixes TypeScript config validation errors identified in IDE/linting tools:

## Changes Made

### ✅ **Root tsconfig.json fixes:**
- **Enable strict mode**: Changed `"strict": false` to `"strict": true` 
- **Clean up path mappings**: Removed duplicate/invalid path references
- **Correct path targets**: Fixed paths to point to actual package locations

### ✅ **Package-level config fixes:**
- **Fixed providers lint config**: Updated `tsconfig.lint.json` to extend proper base config
- **Removed invalid extends**: Replaced non-existent `@repo/typescript-config/pub.json` reference

## Issues Resolved

1. **"strict" should be enabled to reduce type errors** ✅
2. **compilerOptions/paths must NOT have duplicate items** ✅  
3. **Invalid config extends reference** ✅

## Verification

- ✅ All TypeScript type checking passes
- ✅ No new type errors introduced
- ✅ Path mappings work correctly
- ✅ Strict mode enabled across project

This is a **fix** commit that will trigger a patch version bump via release-please when merged.