### PR TITLE
refactor: route errors via hooks, remove local try/catch, parser logging, bench fix

### DIFF
--- a/.changeset/error-flow-cleanup.md
+++ b/.changeset/error-flow-cleanup.md
@@ -1,0 +1,8 @@
+---
+"@cogniformai/instructor-stream": patch
+---
+
+Refactor: route tokenizer/parser errors via hooks (no local try/catch); simplify Error subclasses; 
+streaming parser logs errors; fix Vitest bench usage.
+
+

--- a/packages/benchmarks/simple-bench.ts
+++ b/packages/benchmarks/simple-bench.ts
@@ -28,7 +28,10 @@ async function collectAssignments(json: string): Promise<Array<{ path: Path; val
   const parser = new JSONParser({ stringBufferSize: 0, handleUnescapedNewLines: true })
   const assignments: Array<{ path: Path; value: unknown }> = []
   parser.onToken = ({ parser: p, tokenizer: t }) => {
-    const path = getPathFromStack(p.stack as Array<{ key: string | number | undefined }>, p.key as string | number)
+    const path = getPathFromStack(
+      p.stack as Array<{ key: string | number | undefined }>,
+      p.key as string | number
+    )
     assignments.push({ path, value: t.value })
   }
   parser.onValue = () => void 0

--- a/packages/instructor-stream/src/utils/buffered-string.ts
+++ b/packages/instructor-stream/src/utils/buffered-string.ts
@@ -36,7 +36,7 @@ export class NonBufferedString implements StringBuilder {
 
   public appendChar(char: number): void {
     this.assembled += String.fromCharCode(char)
-    this.byteLength += 1
+    this.byteLength++
     this.update()
   }
 
@@ -91,7 +91,6 @@ export class BufferedString implements StringBuilder {
     if (this.bufferOffset + size > this.buffer.length) {
       this.flushStringBuffer()
     }
-
     this.buffer.set(buf.subarray(start, end), this.bufferOffset)
     this.bufferOffset += size
     this.byteLength += size
@@ -115,6 +114,7 @@ export class BufferedString implements StringBuilder {
     this.bufferOffset = 0
     this.byteLength = 0
   }
+
   public toString(): string {
     /**  Flush without notifying to avoid emitting an extra partial update */
     this.string += this.decoder.decode(this.buffer.subarray(0, this.bufferOffset))

--- a/packages/instructor-stream/src/utils/path.ts
+++ b/packages/instructor-stream/src/utils/path.ts
@@ -56,7 +56,7 @@ export function setDeep(obj: Indexable, path: Path, value: unknown): void {
     const key = path[i]
     const nextKey = path[i + 1]
     if ((current as Indexable)[key] == null) {
-      // Decide container type based on next key
+      /** Decide container type based on next key */
       ;(current as Indexable)[key] = typeof nextKey === 'number' ? [] : {}
     }
     current = (current as Indexable)[key] as Indexable

--- a/packages/instructor-stream/src/utils/token-type.ts
+++ b/packages/instructor-stream/src/utils/token-type.ts
@@ -1,6 +1,3 @@
-// TODO: Should this be converted to literals as TS Enums are now
-// discouraged we can use as const instead and get better type inference?
-// This looks like what they were doing below, converting to string literals.
 enum TokenType {
   LEFT_BRACE,
   RIGHT_BRACE,
@@ -14,23 +11,6 @@ enum TokenType {
   STRING,
   NUMBER,
   SEPARATOR,
-}
-
-export function TokenTypeToString(tokenType: TokenType): string {
-  return [
-    'LEFT_BRACE',
-    'RIGHT_BRACE',
-    'LEFT_BRACKET',
-    'RIGHT_BRACKET',
-    'COLON',
-    'COMMA',
-    'TRUE',
-    'FALSE',
-    'NULL',
-    'STRING',
-    'NUMBER',
-    'SEPARATOR',
-  ][tokenType]
 }
 
 export default TokenType

--- a/packages/instructor-stream/src/utils/tokenizer.ts
+++ b/packages/instructor-stream/src/utils/tokenizer.ts
@@ -13,7 +13,6 @@ import type { ParsedTokenInfo, StringBuilder } from '@/utils/index.ts'
 import TokenType from './token-type.ts'
 import { charset, escapedSequences } from './utf-8.js'
 
-// TODO: Convert these from enums to strings as enums are now discouraged in ts.
 const enum TokenizerStates {
   START,
   ENDED,
@@ -95,10 +94,9 @@ const defaultOpts: TokenizerOptions = {
 }
 
 export class TokenizerError extends Error {
+  name = 'TokenizerError'
   constructor(message: string) {
     super(message)
-    // Typescript is broken. This is a workaround
-    Object.setPrototypeOf(this, TokenizerError.prototype)
   }
 }
 
@@ -152,490 +150,487 @@ export default class Tokenizer {
   }
 
   public write(input: Iterable<number> | string): void {
-    try {
-      let buffer: Uint8Array
-      if (input instanceof Uint8Array) {
-        buffer = input
-      } else if (typeof input === 'string') {
-        buffer = this.encoder.encode(input)
-      } else if ((typeof input === 'object' && 'buffer' in input) || Array.isArray(input)) {
-        buffer = Uint8Array.from(input)
-      } else {
-        // TODO: clean up locally thrown exception this is a long way from the catch block
-        // Will determine later if this is where it should be thrown
-        throw new TypeError(
+    let buffer: Uint8Array
+    if (input instanceof Uint8Array) {
+      buffer = input
+    } else if (typeof input === 'string') {
+      buffer = this.encoder.encode(input)
+    } else if ((typeof input === 'object' && 'buffer' in input) || Array.isArray(input)) {
+      buffer = Uint8Array.from(input)
+    } else {
+      /** Signal error and exit early instead of throwing locally */
+      return this.error(
+        new TypeError(
           'Unexpected type. The `write` function only accepts Arrays, TypedArrays and Strings.'
         )
-      }
+      )
+    }
 
-      for (let i = 0; i < buffer.length; i += 1) {
-        const n = buffer[i] // get current byte from buffer
-        switch (this.state) {
-          case TokenizerStates.START:
-            this.offset += 1
+    for (let i = 0; i < buffer.length; i++) {
+      const n = buffer[i] // get current byte from buffer
+      switch (this.state) {
+        case TokenizerStates.START:
+          this.offset++
 
-            if (this.separatorBytes && n === this.separatorBytes[0]) {
-              if (this.separatorBytes.length === 1) {
-                this.state = TokenizerStates.START
-                this.onToken({
-                  token: TokenType.SEPARATOR,
-                  value: this.separator as string,
-                  offset: this.offset + this.separatorBytes.length - 1,
-                })
-                continue
-              }
-              this.state = TokenizerStates.SEPARATOR
-              continue
-            }
-
-            if (
-              n === charset.SPACE ||
-              n === charset.NEWLINE ||
-              n === charset.CARRIAGE_RETURN ||
-              n === charset.TAB
-            ) {
-              // whitespace
-              continue
-            }
-
-            if (n === charset.LEFT_CURLY_BRACKET) {
-              this.onToken({
-                token: TokenType.LEFT_BRACE,
-                value: '{',
-                offset: this.offset,
-              })
-              continue
-            }
-            if (n === charset.RIGHT_CURLY_BRACKET) {
-              this.onToken({
-                token: TokenType.RIGHT_BRACE,
-                value: '}',
-                offset: this.offset,
-              })
-              continue
-            }
-            if (n === charset.LEFT_SQUARE_BRACKET) {
-              this.onToken({
-                token: TokenType.LEFT_BRACKET,
-                value: '[',
-                offset: this.offset,
-              })
-              continue
-            }
-            if (n === charset.RIGHT_SQUARE_BRACKET) {
-              this.onToken({
-                token: TokenType.RIGHT_BRACKET,
-                value: ']',
-                offset: this.offset,
-              })
-              continue
-            }
-            if (n === charset.COLON) {
-              this.onToken({
-                token: TokenType.COLON,
-                value: ':',
-                offset: this.offset,
-              })
-              continue
-            }
-            if (n === charset.COMMA) {
-              this.onToken({
-                token: TokenType.COMMA,
-                value: ',',
-                offset: this.offset,
-              })
-              continue
-            }
-
-            if (n === charset.LATIN_SMALL_LETTER_T) {
-              this.state = TokenizerStates.TRUE1
-              continue
-            }
-
-            if (n === charset.LATIN_SMALL_LETTER_F) {
-              this.state = TokenizerStates.FALSE1
-              continue
-            }
-
-            if (n === charset.LATIN_SMALL_LETTER_N) {
-              this.state = TokenizerStates.NULL1
-              continue
-            }
-
-            if (n === charset.QUOTATION_MARK) {
-              this.bufferedString.reset()
-              this.state = TokenizerStates.STRING_DEFAULT
-              continue
-            }
-
-            if (n >= charset.DIGIT_ONE && n <= charset.DIGIT_NINE) {
-              this.bufferedNumber.reset()
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO
-              continue
-            }
-
-            if (n === charset.DIGIT_ZERO) {
-              this.bufferedNumber.reset()
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_INITIAL_ZERO
-              continue
-            }
-
-            if (n === charset.HYPHEN_MINUS) {
-              this.bufferedNumber.reset()
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_INITIAL_MINUS
-              continue
-            }
-
-            break
-          // STRING
-          case TokenizerStates.STRING_DEFAULT:
-            if (this.handleUnescapedNewLines && n === charset.NEWLINE) {
-              this.bufferedString.appendChar(charset.REVERSE_SOLIDUS) // Appends '\'
-              this.bufferedString.appendChar(charset.LATIN_SMALL_LETTER_N) // Appends 'n'
-              continue
-            }
-
-            if (n === charset.QUOTATION_MARK) {
-              const string = this.bufferedString.toString()
-              this.state = TokenizerStates.START
-              this.onToken({
-                token: TokenType.STRING,
-                value: string,
-                offset: this.offset,
-              })
-              this.offset += this.bufferedString.byteLength + 1
-              continue
-            }
-
-            if (n === charset.REVERSE_SOLIDUS) {
-              this.state = TokenizerStates.STRING_AFTER_BACKSLASH
-              continue
-            }
-
-            if (n >= 128) {
-              // Parse multi byte (>=128) chars one at a time
-              if (n >= 194 && n <= 223) {
-                this.bytes_in_sequence = 2
-              } else if (n <= 239) {
-                this.bytes_in_sequence = 3
-              } else {
-                this.bytes_in_sequence = 4
-              }
-
-              if (this.bytes_in_sequence <= buffer.length - i) {
-                // if bytes needed to complete char fall outside buffer length, we have a boundary split
-                this.bufferedString.appendBuf(buffer, i, i + this.bytes_in_sequence)
-                i += this.bytes_in_sequence - 1
-                continue
-              }
-
-              this.bytes_remaining = i + this.bytes_in_sequence - buffer.length
-              this.char_split_buffer.set(buffer.subarray(i))
-              i = buffer.length - 1
-              this.state = TokenizerStates.STRING_INCOMPLETE_CHAR
-              continue
-            }
-
-            if (n >= charset.SPACE) {
-              this.bufferedString.appendChar(n)
-              continue
-            }
-
-            break
-          case TokenizerStates.STRING_INCOMPLETE_CHAR:
-            // check for carry over of a multi byte char split between data chunks
-            // & fill temp buffer it with start of this data chunk up to the boundary limit set in the last iteration
-            this.char_split_buffer.set(
-              buffer.subarray(i, i + this.bytes_remaining),
-              this.bytes_in_sequence - this.bytes_remaining
-            )
-            this.bufferedString.appendBuf(this.char_split_buffer, 0, this.bytes_in_sequence)
-            i = this.bytes_remaining - 1
-            this.state = TokenizerStates.STRING_DEFAULT
-            continue
-          case TokenizerStates.STRING_AFTER_BACKSLASH:
-            if (escapedSequences?.[n]) {
-              this.bufferedString.appendChar(escapedSequences[n])
-              this.state = TokenizerStates.STRING_DEFAULT
-              continue
-            }
-
-            if (n === charset.LATIN_SMALL_LETTER_U) {
-              this.unicode = ''
-              this.state = TokenizerStates.STRING_UNICODE_DIGIT_1
-              continue
-            }
-
-            break
-          case TokenizerStates.STRING_UNICODE_DIGIT_1:
-          case TokenizerStates.STRING_UNICODE_DIGIT_2:
-          case TokenizerStates.STRING_UNICODE_DIGIT_3:
-            if (
-              (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) ||
-              (n >= charset.LATIN_CAPITAL_LETTER_A && n <= charset.LATIN_CAPITAL_LETTER_F) ||
-              (n >= charset.LATIN_SMALL_LETTER_A && n <= charset.LATIN_SMALL_LETTER_F)
-            ) {
-              this.unicode += String.fromCharCode(n)
-              this.state += 1
-              continue
-            }
-            break
-          case TokenizerStates.STRING_UNICODE_DIGIT_4:
-            if (
-              (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) ||
-              (n >= charset.LATIN_CAPITAL_LETTER_A && n <= charset.LATIN_CAPITAL_LETTER_F) ||
-              (n >= charset.LATIN_SMALL_LETTER_A && n <= charset.LATIN_SMALL_LETTER_F)
-            ) {
-              const intVal = parseInt(this.unicode + String.fromCharCode(n), 16)
-              if (this.highSurrogate === undefined) {
-                if (intVal >= 0xd800 && intVal <= 0xdbff) {
-                  //<55296,56319> - highSurrogate
-                  this.highSurrogate = intVal
-                } else {
-                  this.bufferedString.appendBuf(this.encoder.encode(String.fromCharCode(intVal)))
-                }
-              } else {
-                if (intVal >= 0xdc00 && intVal <= 0xdfff) {
-                  //<56320,57343> - lowSurrogate
-                  this.bufferedString.appendBuf(
-                    this.encoder.encode(String.fromCharCode(this.highSurrogate, intVal))
-                  )
-                } else {
-                  this.bufferedString.appendBuf(
-                    this.encoder.encode(String.fromCharCode(this.highSurrogate))
-                  )
-                }
-                this.highSurrogate = undefined
-              }
-              this.state = TokenizerStates.STRING_DEFAULT
-              continue
-            }
-            break
-          // Number
-          case TokenizerStates.NUMBER_AFTER_INITIAL_MINUS:
-            if (n === charset.DIGIT_ZERO) {
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_INITIAL_ZERO
-              continue
-            }
-
-            if (n >= charset.DIGIT_ONE && n <= charset.DIGIT_NINE) {
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO
-              continue
-            }
-
-            break
-          case TokenizerStates.NUMBER_AFTER_INITIAL_ZERO:
-            if (n === charset.FULL_STOP) {
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_FULL_STOP
-              continue
-            }
-
-            if (n === charset.LATIN_SMALL_LETTER_E || n === charset.LATIN_CAPITAL_LETTER_E) {
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_E
-              continue
-            }
-
-            i -= 1
-            this.state = TokenizerStates.START
-            this.emitNumber()
-            continue
-          case TokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO:
-            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
-              this.bufferedNumber.appendChar(n)
-              continue
-            }
-
-            if (n === charset.FULL_STOP) {
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_FULL_STOP
-              continue
-            }
-
-            if (n === charset.LATIN_SMALL_LETTER_E || n === charset.LATIN_CAPITAL_LETTER_E) {
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_E
-              continue
-            }
-
-            i -= 1
-            this.state = TokenizerStates.START
-            this.emitNumber()
-            continue
-          case TokenizerStates.NUMBER_AFTER_FULL_STOP:
-            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_DECIMAL
-              continue
-            }
-
-            break
-          case TokenizerStates.NUMBER_AFTER_DECIMAL:
-            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
-              this.bufferedNumber.appendChar(n)
-              continue
-            }
-
-            if (n === charset.LATIN_SMALL_LETTER_E || n === charset.LATIN_CAPITAL_LETTER_E) {
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_E
-              continue
-            }
-
-            i -= 1
-            this.state = TokenizerStates.START
-            this.emitNumber()
-            continue
-          // @ts-expect error fall through case
-          case TokenizerStates.NUMBER_AFTER_E:
-            if (n === charset.PLUS_SIGN || n === charset.HYPHEN_MINUS) {
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_E_AND_SIGN
-              continue
-            }
-          // @ts-expect error fall through case
-          case TokenizerStates.NUMBER_AFTER_E_AND_SIGN:
-            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
-              this.bufferedNumber.appendChar(n)
-              this.state = TokenizerStates.NUMBER_AFTER_E_AND_DIGIT
-              continue
-            }
-
-            break
-          case TokenizerStates.NUMBER_AFTER_E_AND_DIGIT:
-            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
-              this.bufferedNumber.appendChar(n)
-              continue
-            }
-
-            i -= 1
-            this.state = TokenizerStates.START
-            this.emitNumber()
-            continue
-          // TRUE
-          case TokenizerStates.TRUE1:
-            if (n === charset.LATIN_SMALL_LETTER_R) {
-              this.state = TokenizerStates.TRUE2
-              continue
-            }
-            break
-          case TokenizerStates.TRUE2:
-            if (n === charset.LATIN_SMALL_LETTER_U) {
-              this.state = TokenizerStates.TRUE3
-              continue
-            }
-            break
-          case TokenizerStates.TRUE3:
-            if (n === charset.LATIN_SMALL_LETTER_E) {
-              this.state = TokenizerStates.START
-              this.onToken({
-                token: TokenType.TRUE,
-                value: true,
-                offset: this.offset,
-              })
-              this.offset += 3
-              continue
-            }
-            break
-          // FALSE
-          case TokenizerStates.FALSE1:
-            if (n === charset.LATIN_SMALL_LETTER_A) {
-              this.state = TokenizerStates.FALSE2
-              continue
-            }
-            break
-          case TokenizerStates.FALSE2:
-            if (n === charset.LATIN_SMALL_LETTER_L) {
-              this.state = TokenizerStates.FALSE3
-              continue
-            }
-            break
-          case TokenizerStates.FALSE3:
-            if (n === charset.LATIN_SMALL_LETTER_S) {
-              this.state = TokenizerStates.FALSE4
-              continue
-            }
-            break
-          case TokenizerStates.FALSE4:
-            if (n === charset.LATIN_SMALL_LETTER_E) {
-              this.state = TokenizerStates.START
-              this.onToken({
-                token: TokenType.FALSE,
-                value: false,
-                offset: this.offset,
-              })
-              this.offset += 4
-              continue
-            }
-            break
-          // NULL
-          case TokenizerStates.NULL1:
-            if (n === charset.LATIN_SMALL_LETTER_U) {
-              this.state = TokenizerStates.NULL2
-              continue
-            }
-            break
-          case TokenizerStates.NULL2:
-            if (n === charset.LATIN_SMALL_LETTER_L) {
-              this.state = TokenizerStates.NULL3
-              continue
-            }
-            break
-          case TokenizerStates.NULL3:
-            if (n === charset.LATIN_SMALL_LETTER_L) {
-              this.state = TokenizerStates.START
-              this.onToken({
-                token: TokenType.NULL,
-                value: null,
-                offset: this.offset,
-              })
-              this.offset += 3
-              continue
-            }
-            break
-          case TokenizerStates.SEPARATOR:
-            this.separatorIndex += 1
-            if (!this.separatorBytes || n !== this.separatorBytes[this.separatorIndex]) {
-              break
-            }
-            if (this.separatorIndex === this.separatorBytes.length - 1) {
+          if (this.separatorBytes && n === this.separatorBytes[0]) {
+            if (this.separatorBytes.length === 1) {
               this.state = TokenizerStates.START
               this.onToken({
                 token: TokenType.SEPARATOR,
                 value: this.separator as string,
-                offset: this.offset + this.separatorIndex,
+                offset: this.offset + this.separatorBytes.length - 1,
               })
-              this.separatorIndex = 0
-            }
-            continue
-          case TokenizerStates.ENDED:
-            if (
-              n === charset.SPACE ||
-              n === charset.NEWLINE ||
-              n === charset.CARRIAGE_RETURN ||
-              n === charset.TAB
-            ) {
-              // whitespace
               continue
             }
-        }
-        // TODO: This is thrown and caught locally may be a better way
-        // To handle this error
-        throw new TokenizerError(
+            this.state = TokenizerStates.SEPARATOR
+            continue
+          }
+
+          if (
+            n === charset.SPACE ||
+            n === charset.NEWLINE ||
+            n === charset.CARRIAGE_RETURN ||
+            n === charset.TAB
+          ) {
+            // whitespace
+            continue
+          }
+
+          if (n === charset.LEFT_CURLY_BRACKET) {
+            this.onToken({
+              token: TokenType.LEFT_BRACE,
+              value: '{',
+              offset: this.offset,
+            })
+            continue
+          }
+          if (n === charset.RIGHT_CURLY_BRACKET) {
+            this.onToken({
+              token: TokenType.RIGHT_BRACE,
+              value: '}',
+              offset: this.offset,
+            })
+            continue
+          }
+          if (n === charset.LEFT_SQUARE_BRACKET) {
+            this.onToken({
+              token: TokenType.LEFT_BRACKET,
+              value: '[',
+              offset: this.offset,
+            })
+            continue
+          }
+          if (n === charset.RIGHT_SQUARE_BRACKET) {
+            this.onToken({
+              token: TokenType.RIGHT_BRACKET,
+              value: ']',
+              offset: this.offset,
+            })
+            continue
+          }
+          if (n === charset.COLON) {
+            this.onToken({
+              token: TokenType.COLON,
+              value: ':',
+              offset: this.offset,
+            })
+            continue
+          }
+          if (n === charset.COMMA) {
+            this.onToken({
+              token: TokenType.COMMA,
+              value: ',',
+              offset: this.offset,
+            })
+            continue
+          }
+
+          if (n === charset.LATIN_SMALL_LETTER_T) {
+            this.state = TokenizerStates.TRUE1
+            continue
+          }
+
+          if (n === charset.LATIN_SMALL_LETTER_F) {
+            this.state = TokenizerStates.FALSE1
+            continue
+          }
+
+          if (n === charset.LATIN_SMALL_LETTER_N) {
+            this.state = TokenizerStates.NULL1
+            continue
+          }
+
+          if (n === charset.QUOTATION_MARK) {
+            this.bufferedString.reset()
+            this.state = TokenizerStates.STRING_DEFAULT
+            continue
+          }
+
+          if (n >= charset.DIGIT_ONE && n <= charset.DIGIT_NINE) {
+            this.bufferedNumber.reset()
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO
+            continue
+          }
+
+          if (n === charset.DIGIT_ZERO) {
+            this.bufferedNumber.reset()
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_INITIAL_ZERO
+            continue
+          }
+
+          if (n === charset.HYPHEN_MINUS) {
+            this.bufferedNumber.reset()
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_INITIAL_MINUS
+            continue
+          }
+
+          break
+        // STRING
+        case TokenizerStates.STRING_DEFAULT:
+          if (this.handleUnescapedNewLines && n === charset.NEWLINE) {
+            this.bufferedString.appendChar(charset.REVERSE_SOLIDUS) // Appends '\'
+            this.bufferedString.appendChar(charset.LATIN_SMALL_LETTER_N) // Appends 'n'
+            continue
+          }
+
+          if (n === charset.QUOTATION_MARK) {
+            const string = this.bufferedString.toString()
+            this.state = TokenizerStates.START
+            this.onToken({
+              token: TokenType.STRING,
+              value: string,
+              offset: this.offset,
+            })
+            this.offset += this.bufferedString.byteLength + 1
+            continue
+          }
+
+          if (n === charset.REVERSE_SOLIDUS) {
+            this.state = TokenizerStates.STRING_AFTER_BACKSLASH
+            continue
+          }
+
+          if (n >= 128) {
+            // Parse multi byte (>=128) chars one at a time
+            if (n >= 194 && n <= 223) {
+              this.bytes_in_sequence = 2
+            } else if (n <= 239) {
+              this.bytes_in_sequence = 3
+            } else {
+              this.bytes_in_sequence = 4
+            }
+
+            if (this.bytes_in_sequence <= buffer.length - i) {
+              // if bytes needed to complete char fall outside buffer length, we have a boundary split
+              this.bufferedString.appendBuf(buffer, i, i + this.bytes_in_sequence)
+              i += this.bytes_in_sequence - 1
+              continue
+            }
+
+            this.bytes_remaining = i + this.bytes_in_sequence - buffer.length
+            this.char_split_buffer.set(buffer.subarray(i))
+            i = buffer.length - 1
+            this.state = TokenizerStates.STRING_INCOMPLETE_CHAR
+            continue
+          }
+
+          if (n >= charset.SPACE) {
+            this.bufferedString.appendChar(n)
+            continue
+          }
+
+          break
+        case TokenizerStates.STRING_INCOMPLETE_CHAR:
+          // check for carry over of a multi byte char split between data chunks
+          // & fill temp buffer it with start of this data chunk up to the boundary limit set in the last iteration
+          this.char_split_buffer.set(
+            buffer.subarray(i, i + this.bytes_remaining),
+            this.bytes_in_sequence - this.bytes_remaining
+          )
+          this.bufferedString.appendBuf(this.char_split_buffer, 0, this.bytes_in_sequence)
+          i = this.bytes_remaining - 1
+          this.state = TokenizerStates.STRING_DEFAULT
+          continue
+        case TokenizerStates.STRING_AFTER_BACKSLASH:
+          if (escapedSequences?.[n]) {
+            this.bufferedString.appendChar(escapedSequences[n])
+            this.state = TokenizerStates.STRING_DEFAULT
+            continue
+          }
+
+          if (n === charset.LATIN_SMALL_LETTER_U) {
+            this.unicode = ''
+            this.state = TokenizerStates.STRING_UNICODE_DIGIT_1
+            continue
+          }
+
+          break
+        case TokenizerStates.STRING_UNICODE_DIGIT_1:
+        case TokenizerStates.STRING_UNICODE_DIGIT_2:
+        case TokenizerStates.STRING_UNICODE_DIGIT_3:
+          if (
+            (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) ||
+            (n >= charset.LATIN_CAPITAL_LETTER_A && n <= charset.LATIN_CAPITAL_LETTER_F) ||
+            (n >= charset.LATIN_SMALL_LETTER_A && n <= charset.LATIN_SMALL_LETTER_F)
+          ) {
+            this.unicode += String.fromCharCode(n)
+            this.state += 1
+            continue
+          }
+          break
+        case TokenizerStates.STRING_UNICODE_DIGIT_4:
+          if (
+            (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) ||
+            (n >= charset.LATIN_CAPITAL_LETTER_A && n <= charset.LATIN_CAPITAL_LETTER_F) ||
+            (n >= charset.LATIN_SMALL_LETTER_A && n <= charset.LATIN_SMALL_LETTER_F)
+          ) {
+            const intVal = parseInt(this.unicode + String.fromCharCode(n), 16)
+            if (this.highSurrogate === undefined) {
+              if (intVal >= 0xd8_00 && intVal <= 0xdb_ff) {
+                //<55296,56319> - highSurrogate
+                this.highSurrogate = intVal
+              } else {
+                this.bufferedString.appendBuf(this.encoder.encode(String.fromCharCode(intVal)))
+              }
+            } else {
+              if (intVal >= 0xdc_00 && intVal <= 0xdf_ff) {
+                //<56320,57343> - lowSurrogate
+                this.bufferedString.appendBuf(
+                  this.encoder.encode(String.fromCharCode(this.highSurrogate, intVal))
+                )
+              } else {
+                this.bufferedString.appendBuf(
+                  this.encoder.encode(String.fromCharCode(this.highSurrogate))
+                )
+              }
+              this.highSurrogate = undefined
+            }
+            this.state = TokenizerStates.STRING_DEFAULT
+            continue
+          }
+          break
+        // Number
+        case TokenizerStates.NUMBER_AFTER_INITIAL_MINUS:
+          if (n === charset.DIGIT_ZERO) {
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_INITIAL_ZERO
+            continue
+          }
+
+          if (n >= charset.DIGIT_ONE && n <= charset.DIGIT_NINE) {
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO
+            continue
+          }
+
+          break
+        case TokenizerStates.NUMBER_AFTER_INITIAL_ZERO:
+          if (n === charset.FULL_STOP) {
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_FULL_STOP
+            continue
+          }
+
+          if (n === charset.LATIN_SMALL_LETTER_E || n === charset.LATIN_CAPITAL_LETTER_E) {
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_E
+            continue
+          }
+
+          i--
+          this.state = TokenizerStates.START
+          this.emitNumber()
+          continue
+        case TokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO:
+          if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+            this.bufferedNumber.appendChar(n)
+            continue
+          }
+
+          if (n === charset.FULL_STOP) {
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_FULL_STOP
+            continue
+          }
+
+          if (n === charset.LATIN_SMALL_LETTER_E || n === charset.LATIN_CAPITAL_LETTER_E) {
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_E
+            continue
+          }
+
+          i--
+          this.state = TokenizerStates.START
+          this.emitNumber()
+          continue
+        case TokenizerStates.NUMBER_AFTER_FULL_STOP:
+          if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_DECIMAL
+            continue
+          }
+
+          break
+        case TokenizerStates.NUMBER_AFTER_DECIMAL:
+          if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+            this.bufferedNumber.appendChar(n)
+            continue
+          }
+
+          if (n === charset.LATIN_SMALL_LETTER_E || n === charset.LATIN_CAPITAL_LETTER_E) {
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_E
+            continue
+          }
+
+          i--
+          this.state = TokenizerStates.START
+          this.emitNumber()
+          continue
+        // @ts-expect error fall through case
+        case TokenizerStates.NUMBER_AFTER_E:
+          if (n === charset.PLUS_SIGN || n === charset.HYPHEN_MINUS) {
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_E_AND_SIGN
+            continue
+          }
+        // @ts-expect error fall through case
+        case TokenizerStates.NUMBER_AFTER_E_AND_SIGN:
+          if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+            this.bufferedNumber.appendChar(n)
+            this.state = TokenizerStates.NUMBER_AFTER_E_AND_DIGIT
+            continue
+          }
+
+          break
+        case TokenizerStates.NUMBER_AFTER_E_AND_DIGIT:
+          if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+            this.bufferedNumber.appendChar(n)
+            continue
+          }
+
+          i--
+          this.state = TokenizerStates.START
+          this.emitNumber()
+          continue
+        // TRUE
+        case TokenizerStates.TRUE1:
+          if (n === charset.LATIN_SMALL_LETTER_R) {
+            this.state = TokenizerStates.TRUE2
+            continue
+          }
+          break
+        case TokenizerStates.TRUE2:
+          if (n === charset.LATIN_SMALL_LETTER_U) {
+            this.state = TokenizerStates.TRUE3
+            continue
+          }
+          break
+        case TokenizerStates.TRUE3:
+          if (n === charset.LATIN_SMALL_LETTER_E) {
+            this.state = TokenizerStates.START
+            this.onToken({
+              token: TokenType.TRUE,
+              value: true,
+              offset: this.offset,
+            })
+            this.offset += 3
+            continue
+          }
+          break
+        // FALSE
+        case TokenizerStates.FALSE1:
+          if (n === charset.LATIN_SMALL_LETTER_A) {
+            this.state = TokenizerStates.FALSE2
+            continue
+          }
+          break
+        case TokenizerStates.FALSE2:
+          if (n === charset.LATIN_SMALL_LETTER_L) {
+            this.state = TokenizerStates.FALSE3
+            continue
+          }
+          break
+        case TokenizerStates.FALSE3:
+          if (n === charset.LATIN_SMALL_LETTER_S) {
+            this.state = TokenizerStates.FALSE4
+            continue
+          }
+          break
+        case TokenizerStates.FALSE4:
+          if (n === charset.LATIN_SMALL_LETTER_E) {
+            this.state = TokenizerStates.START
+            this.onToken({
+              token: TokenType.FALSE,
+              value: false,
+              offset: this.offset,
+            })
+            this.offset += 4
+            continue
+          }
+          break
+        // NULL
+        case TokenizerStates.NULL1:
+          if (n === charset.LATIN_SMALL_LETTER_U) {
+            this.state = TokenizerStates.NULL2
+            continue
+          }
+          break
+        case TokenizerStates.NULL2:
+          if (n === charset.LATIN_SMALL_LETTER_L) {
+            this.state = TokenizerStates.NULL3
+            continue
+          }
+          break
+        case TokenizerStates.NULL3:
+          if (n === charset.LATIN_SMALL_LETTER_L) {
+            this.state = TokenizerStates.START
+            this.onToken({
+              token: TokenType.NULL,
+              value: null,
+              offset: this.offset,
+            })
+            this.offset += 3
+            continue
+          }
+          break
+        case TokenizerStates.SEPARATOR:
+          this.separatorIndex++
+          if (!this.separatorBytes || n !== this.separatorBytes[this.separatorIndex]) {
+            break
+          }
+          if (this.separatorIndex === this.separatorBytes.length - 1) {
+            this.state = TokenizerStates.START
+            this.onToken({
+              token: TokenType.SEPARATOR,
+              value: this.separator as string,
+              offset: this.offset + this.separatorIndex,
+            })
+            this.separatorIndex = 0
+          }
+          continue
+        case TokenizerStates.ENDED:
+          if (
+            n === charset.SPACE ||
+            n === charset.NEWLINE ||
+            n === charset.CARRIAGE_RETURN ||
+            n === charset.TAB
+          ) {
+            // whitespace
+            continue
+          }
+      }
+      // Signal error and stop processing
+      return this.error(
+        new TokenizerError(
           `Unexpected "${String.fromCharCode(
             n
           )}" at position "${i}" in state ${TokenizerStateToString(this.state)}`
         )
-      }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
-      this.error(err)
+      )
     }
   }
 


### PR DESCRIPTION
Description:
- Summary
  - Route tokenizer/parser errors via error hooks; no local try/catch.
  - Simplify Error subclasses; remove prototype hack.
  - Streaming parser logs errors (tests expect logging, not throws).
  - Fix Vitest bench usage (options moved to third arg; no returns from bench fns).
  - Keep hot path free of string mappings; TokenTypeToString was unused and removed.

- Impact
  - Behavior on invalid input: error hooks invoked, no thrown exceptions within hot path.
  - Tests: all green locally (139/139).
  - Publishing: includes a Changeset (patch) for `@cogniformai/instructor-stream` only.

- Release
  - After merge, Changesets will open a “chore: update versions” PR.
  - Merge that release PR to publish `@cogniformai/instructor-stream`.